### PR TITLE
Update i2c.cc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i2c",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Native bindings for i2c-dev. Plays well with Raspberry Pi and BeagleBone.",
   "main": "main.js",
   "author": "Kelly Korevec",

--- a/src/i2c.cc
+++ b/src/i2c.cc
@@ -159,7 +159,11 @@ void ReadBlock(const FunctionCallbackInfo<Value>& args) {
   int32_t len = args[1]->Int32Value();
   uint8_t data[len]; 
   Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+#if( NODE_MAJOR_VERSION >= 4 )
+  Local<Object> buffer = node::Buffer::New(isolate, len).ToLocalChecked();
+#else
   Local<Object> buffer = node::Buffer::New(len);
+#endif
 
   while (fd > 0) {
     if (i2c_smbus_read_i2c_block_data(fd, cmd, len, data) != len) {


### PR DESCRIPTION
Buffer::New constructor changed moving into node v4.

This is the quickest and dirtiest way to make it compatible with all. (+1 squashed commit)
Squashed commits:
[67a2a1f] Update package.json

NOW it's compatible with node > 0.12.0